### PR TITLE
[BUGFIX] RealURL Configuration not processed

### DIFF
--- a/Classes/Generator/EntryPoint.php
+++ b/Classes/Generator/EntryPoint.php
@@ -81,6 +81,7 @@ class EntryPoint {
 		/** @var \TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController $tsfe */
 		$tsfe->connectToDB();
 		$tsfe->initFEuser();
+		$tsfe->checkAlternativeIdMethods();
 		$tsfe->determineId();
 		\TYPO3\CMS\Core\Core\Bootstrap::getInstance()->loadCachedTca();
 		$tsfe->initTemplate();


### PR DESCRIPTION
In the eID initialization RealURL is not processed.
This can be beneficial for language handling via domain names.

Resolves: #42
