### PR TITLE
[BUGFIX] RealURL Configuration not processed

### DIFF
--- a/class.tx_ddgooglesitemap_eid.php
+++ b/class.tx_ddgooglesitemap_eid.php
@@ -76,6 +76,7 @@ class tx_ddgooglesitemap_eid {
 		$GLOBALS['TSFE'] = t3lib_div::makeInstance('tslib_fe', $GLOBALS['TYPO3_CONF_VARS'], t3lib_div::_GP('id'), '');
 		$GLOBALS['TSFE']->connectToDB();
 		$GLOBALS['TSFE']->initFEuser();
+		$GLOBALS['TSFE']->checkAlternativeIdMethods();
 		$GLOBALS['TSFE']->determineId();
 		if (version_compare(TYPO3_branch, '6.1', '>=')) {
 			\TYPO3\CMS\Core\Core\Bootstrap::getInstance()->loadCachedTca();


### PR DESCRIPTION
In the eID initialization RealURL is not processed.
This can be beneficial for language handling via domain names.

Resolves: #42
