### PR TITLE
TCA has to be loaded before determining the id, when the cache is empty.

### DIFF
--- a/Classes/Generator/EntryPoint.php
+++ b/Classes/Generator/EntryPoint.php
@@ -81,8 +81,8 @@ class EntryPoint {
 		/** @var \TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController $tsfe */
 		$tsfe->connectToDB();
 		$tsfe->initFEuser();
-		$tsfe->determineId();
 		\TYPO3\CMS\Core\Core\Bootstrap::getInstance()->loadCachedTca();
+		$tsfe->determineId();
 		$tsfe->initTemplate();
 		$tsfe->getConfigArray();
 


### PR DESCRIPTION
https://github.com/dmitryd/typo3-dd_googlesitemap/issues/48