### PR TITLE
fixed typo in priorities list (see issue #52)

### DIFF
--- a/ext_tables.php
+++ b/ext_tables.php
@@ -24,7 +24,7 @@ $tempColumns = Array (
 				array('LLL:EXT:dd_googlesitemap/locallang.xml:pages.tx_ddgooglesitemap_priority.6', 6),
 				array('LLL:EXT:dd_googlesitemap/locallang.xml:pages.tx_ddgooglesitemap_priority.7', 7),
 				array('LLL:EXT:dd_googlesitemap/locallang.xml:pages.tx_ddgooglesitemap_priority.8', 8),
-				array('LLL:EXT:dd_googlesitemap/locallang.xml:pages.tx_ddgooglesitemap_priority.8', 9),
+				array('LLL:EXT:dd_googlesitemap/locallang.xml:pages.tx_ddgooglesitemap_priority.9', 9),
 				array('LLL:EXT:dd_googlesitemap/locallang.xml:pages.tx_ddgooglesitemap_priority.10', 10),
 			)
 		)


### PR DESCRIPTION
This one line change fixes a typo in ext_tables.php introduced with commit 6e48f95728cb3b431df0818711af12214bf877b6