### PR TITLE
[BUGFIX] Add renderType to priority select field

### DIFF
--- a/ext_tables.php
+++ b/ext_tables.php
@@ -14,6 +14,7 @@ $tempColumns = Array (
 		'displayCond' => 'FIELD:no_search:=:0',
 		'config' => array(
 			'type' => 'select',
+			'renderType' => 'selectSingle',
 			'items' => array(
 				array('LLL:EXT:dd_googlesitemap/locallang.xml:pages.tx_ddgooglesitemap_priority.0', 0),
 				array('LLL:EXT:dd_googlesitemap/locallang.xml:pages.tx_ddgooglesitemap_priority.1', 1),


### PR DESCRIPTION
The renderType option is required for type: select in TCA of TYPO3 7.6.