### PR TITLE
changes deprecated call PageGenerator::pagegenInit()

### DIFF
--- a/Classes/Generator/EntryPoint.php
+++ b/Classes/Generator/EntryPoint.php
@@ -88,7 +88,7 @@ class EntryPoint {
 		$tsfe->settingLanguage();
 
 		// Get linkVars, absRefPrefix, etc
-		\TYPO3\CMS\Frontend\Page\PageGenerator::pagegenInit();
+		$tsfe->preparePageContentGeneration();
 	}
 }
 


### PR DESCRIPTION
PageGenerator::pagegenInit() is throwing error in v9